### PR TITLE
Protect against accidental redis flushdb

### DIFF
--- a/test/ohm.rb
+++ b/test/ohm.rb
@@ -14,6 +14,10 @@ class User < Ohm::Model
 end
 
 prepare do
+  Ohm.connect :db => ENV.fetch("SHIELD_TEST_REDIS_DB", 15)
+  unless Ohm.redis.keys.empty?
+    raise "Redis db has data! Aborting tests to prevent flushdb!"
+  end
   Ohm.flush
 end
 
@@ -23,8 +27,10 @@ end
 
 test "fetch" do |user|
   assert_equal user, User.fetch("foo@bar.com")
+  Ohm.flush
 end
 
 test "authenticate" do |user|
   assert_equal user, User.authenticate("foo@bar.com", "pass1234")
+  Ohm.flush
 end


### PR DESCRIPTION
Since the ohm test connects against redis db 0 which is probably
the most commonly used, and doesn't precheck for data, running
tests could result in accidental localhost dataloss.

Worst case, the code is a little ugly and spins their CPU if they
have tons of keys but better than dataloss.
