### PR TITLE
Clear the session on authenticate

### DIFF
--- a/lib/shield.rb
+++ b/lib/shield.rb
@@ -46,6 +46,7 @@ module Shield
     end
 
     def authenticate(user)
+      session.clear
       session[user.class.to_s] = user.id
     end
 

--- a/tests/shield_test.rb
+++ b/tests/shield_test.rb
@@ -87,7 +87,9 @@ test "logout" do |context|
 end
 
 test "authenticate" do |context|
+  context.session["no_fixation"] = 1
   context.authenticate(User[1001])
 
   assert User[1] == context.authenticated(User)
+  assert nil == context.session["no_fixation"]
 end


### PR DESCRIPTION
I believe clearning the session before setting session authentication
is standard practice to avoid session fixation attacks.
