### PR TITLE
Fix a minor typo in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ class User
 
   # ...
 
-  self.[](id)
+  def self.[](id)
     get id
   end
 end


### PR DESCRIPTION
Hey there,

First of all, great job!

This PR just add a missing `def` keyword in one of the examples.
